### PR TITLE
[Style] 로그인 페이지 컴포넌트 제작 및 배치 #6

### DIFF
--- a/src/components/common/HorizonLine.tsx
+++ b/src/components/common/HorizonLine.tsx
@@ -1,0 +1,25 @@
+import { twMerge } from 'tailwind-merge';
+
+type HorizonLineProps = {
+  text?: string;
+  className?: string;
+};
+
+const HorizonLine = ({ text, className }: HorizonLineProps) => {
+  return (
+    <div
+      className={twMerge(
+        'my-8 flex w-full items-center justify-center',
+        className
+      )}
+    >
+      <hr className='flex-grow border-t border-gray-300' />
+      {text && (
+        <span className='z-10 mx-4 bg-white px-4 text-gray-500'>{text}</span>
+      )}
+      <hr className='flex-grow border-t border-gray-300' />
+    </div>
+  );
+};
+
+export default HorizonLine;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -36,7 +36,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       <div className='relative w-full'>
         <input
           ref={inputRef}
-          className='ring-outline-gray placeholder:text-outline-gray focus:ring-main-pink w-full rounded-lg border-0 px-4 py-4 ring-1 outline-none ring-inset focus:ring-2 focus:ring-inset'
+          className='ring-outline-gray placeholder:text-outline-gray focus:ring-main-pink shadow-dark-50 w-full rounded-lg border-0 px-4 py-4 ring-1 outline-none ring-inset focus:ring-2 focus:ring-inset'
           onChange={handleInputChange}
           {...props}
         />

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom';
+import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
+
+const LoginForm = () => {
+  const handleSubmitLogin = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
+
+  return (
+    <form onSubmit={handleSubmitLogin} className='flex w-full flex-col gap-4'>
+      <div className=''>
+        <label
+          htmlFor='email-input'
+          className='block pb-2 text-sm font-medium text-gray-700'
+        >
+          Email
+        </label>
+        <Input
+          id='email-input'
+          type='email'
+          placeholder='k@example.com'
+          // value={email}
+          // onChange={handleEmailChange}
+          // onClear={() => setEmail('')}
+        />
+      </div>
+
+      <div className=''>
+        <div className='flex items-center justify-between'>
+          <label
+            htmlFor='password-input'
+            className='block pb-2 text-sm font-medium text-gray-700'
+          >
+            Password
+          </label>
+          <Link to='/' className='text-main-pink text-sm hover:underline'>
+            Forgot Password?
+          </Link>
+        </div>
+        <Input
+          id='password-input'
+          type='password'
+          placeholder='Password'
+          // value={password}
+          // onChange={handlePasswordChange}
+          // onClear={() => setPassword('')}
+        />
+      </div>
+
+      <Button type='submit' variant='active' className='mt-5'>
+        Login
+      </Button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/components/login/SocialLoginButtons.tsx
+++ b/src/components/login/SocialLoginButtons.tsx
@@ -1,0 +1,28 @@
+import Button from '@/components/common/Button';
+
+const SocialLoginButtons = () => {
+  const socialButtons = [
+    {
+      id: 'google',
+      content: 'Google',
+      onClick: () => console.log('Google 로그인'),
+    },
+    {
+      id: 'apple',
+      content: 'Apple',
+      onClick: () => console.log('Apple 로그인'),
+    },
+  ];
+
+  return (
+    <div className='flex justify-center gap-2'>
+      {socialButtons.map((button) => (
+        <Button key={button.id} variant='cancel' onClick={button.onClick}>
+          {button.content}
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default SocialLoginButtons;

--- a/src/components/login/WelcomeCard.tsx
+++ b/src/components/login/WelcomeCard.tsx
@@ -1,0 +1,38 @@
+import Logo from '@/assets/header/logo_sm.svg';
+
+type WelcomeCardProps = {
+  accountQuestionText: string;
+  linkText: string;
+  linkHref: string;
+};
+
+const WelcomeCard = ({
+  accountQuestionText,
+  linkText,
+  linkHref,
+}: WelcomeCardProps) => {
+  return (
+    <div className='flex flex-col items-center justify-center p-8 text-center'>
+      <img
+        src={Logo}
+        alt='Small Logo'
+        width='117'
+        height='30'
+        className='mb-8'
+      />
+      <h1 className='text-3xl font-bold text-gray-800'>Welcome to Korip.</h1>
+      <p className='text-md text-gray-600'>
+        {' '}
+        {accountQuestionText}{' '}
+        <a
+          href={linkHref}
+          className='text-gray-800 underline hover:text-gray-900'
+        >
+          {linkText}
+        </a>
+      </p>
+    </div>
+  );
+};
+
+export default WelcomeCard;

--- a/src/pages/loginPage.tsx
+++ b/src/pages/loginPage.tsx
@@ -1,7 +1,21 @@
-import React from 'react';
+import HorizonLine from '@/components/common/HorizonLine';
+import LoginForm from '@/components/login/LoginForm';
+import WelcomeCard from '@/components/login/WelcomeCard';
+import SocialLoginButtons from '@/components/login/SocialLoginButtons';
 
 const LoginPage = () => {
-  return <div>loginPage</div>;
+  return (
+    <div className='w-full flex-col items-center justify-center p-8'>
+      <WelcomeCard
+        accountQuestionText="Don't have an account?"
+        linkText='Sign Up'
+        linkHref='/signup'
+      />
+      <LoginForm />
+      <HorizonLine text='Or continue with  ' />
+      <SocialLoginButtons />
+    </div>
+  );
 };
 
 export default LoginPage;


### PR DESCRIPTION
### 🌎Pull Request

> ### #️⃣연관되어 있는 이슈
#6 

> ### PR Type
> - [ ] STYLE :lipstick:: CSS 등 사용자 UI 디자인 변경

> ### Description
1. 공통 -> [ 가로선 { 내용 } 가로선 ] 컴포넌트 개발
2. 로그인, 회원가입 상단에 있는 [ Welcome~ ] 안내문 컴포넌트 개발
3. 로그인 페이지 로그인 관련 컴포넌트 배치

> ### Screenshot
![image](https://github.com/user-attachments/assets/dbfeb25c-3727-4a13-83bc-3686e4837a8e)

> ### Discussion
> ui 위주로 해서 zod랑 useForm은 아직입니다. 
